### PR TITLE
Update the look for the FAB button.

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -20,8 +20,9 @@ android {
         applicationId "com.pajato.argus"
         minSdkVersion 19
         targetSdkVersion 28
-        versionCode 1
-        versionName "1.0"
+        versionCode 6
+        versionName "1.3.2"
+        vectorDrawables.useSupportLibrary = true
         testInstrumentationRunner "android.support.test.runner.AndroidJUnitRunner"
     }
     buildTypes {
@@ -32,6 +33,11 @@ android {
             minifyEnabled false
             proguardFiles getDefaultProguardFile('proguard-android-optimize.txt'), 'proguard-rules.pro'
         }
+    }
+
+    compileOptions {
+        sourceCompatibility JavaVersion.VERSION_1_8
+        targetCompatibility JavaVersion.VERSION_1_8
     }
 }
 

--- a/app/src/androidTest/java/com/pajato/argus/MainActivityTest.kt
+++ b/app/src/androidTest/java/com/pajato/argus/MainActivityTest.kt
@@ -9,7 +9,6 @@ import android.support.test.espresso.matcher.ViewMatchers.*
 import android.support.test.rule.ActivityTestRule
 import android.support.test.runner.AndroidJUnit4
 import android.view.Menu
-import org.hamcrest.Matchers.allOf
 import org.junit.Assert
 import org.junit.Rule
 import org.junit.Test
@@ -31,28 +30,22 @@ class MainActivityTest {
     }
 
     @Test
-    fun clicking_on_the_FAB_button_triggers_the_anonymous_handler() {
-        onView(withId(R.id.fab)).check(matches(isDisplayed())).perform(click())
-        onView(allOf(withId(android.support.design.R.id.snackbar_text), withText("Replace with your own action")))
-                .check(matches(isDisplayed()))
-    }
-    @Test
     fun onCreateOptionsMenu() {
         val activity = rule.activity
-        openActionBarOverflowOrOptionsMenu(getInstrumentation().getTargetContext())
+        openActionBarOverflowOrOptionsMenu(getInstrumentation().targetContext)
         Assert.assertTrue(activity.optionsMenu is Menu)
     }
 
     @Test
     fun onOptionsItemSelectedWithNormalItem() {
-        openActionBarOverflowOrOptionsMenu(getInstrumentation().getTargetContext())
+        openActionBarOverflowOrOptionsMenu(getInstrumentation().targetContext)
         onView(withText("Settings")).perform(click())
     }
 
     @Test
     fun onOptionsItemSelectedWithTestItem() {
         val activity = rule.activity
-        openActionBarOverflowOrOptionsMenu(getInstrumentation().getTargetContext())
+        openActionBarOverflowOrOptionsMenu(getInstrumentation().targetContext)
         activity.optionsMenu?.apply {
             activity.onOptionsItemSelected(findItem(R.id.test))
             return
@@ -63,7 +56,7 @@ class MainActivityTest {
     @Test
     fun testSetOptionsMenu() {
         val activity = rule.activity
-        openActionBarOverflowOrOptionsMenu(getInstrumentation().getTargetContext())
+        openActionBarOverflowOrOptionsMenu(getInstrumentation().targetContext)
         val menu = activity.optionsMenu
         activity.optionsMenu = menu
     }

--- a/app/src/main/java/com/pajato/argus/MainActivity.kt
+++ b/app/src/main/java/com/pajato/argus/MainActivity.kt
@@ -1,13 +1,11 @@
 package com.pajato.argus
 
 import android.os.Bundle
-import android.support.design.widget.Snackbar
 import android.support.v7.app.AppCompatActivity
 import android.view.Menu
 import android.view.MenuItem
 import kotlinx.android.extensions.CacheImplementation
 import kotlinx.android.extensions.ContainerOptions
-import kotlinx.android.synthetic.main.activity_main.fab
 import kotlinx.android.synthetic.main.activity_main.toolbar
 
 
@@ -21,10 +19,7 @@ class MainActivity : AppCompatActivity() {
         setContentView(R.layout.activity_main)
         setSupportActionBar(toolbar)
 
-        fab.setOnClickListener { view ->
-            Snackbar.make(view, "Replace with your own action", Snackbar.LENGTH_LONG)
-                    .setAction("Action", null).show()
-        }
+        // TODO flesh this out: fab.setOnClickListener { view -> }
     }
 
 

--- a/app/src/main/res/drawable/ic_add_black_24dp.xml
+++ b/app/src/main/res/drawable/ic_add_black_24dp.xml
@@ -1,0 +1,9 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+        android:width="24dp"
+        android:height="24dp"
+        android:viewportWidth="24.0"
+        android:viewportHeight="24.0">
+    <path
+        android:fillColor="#FF000000"
+        android:pathData="M19,13h-6v6h-2v-6H5v-2h6V5h2v6h6v2z"/>
+</vector>

--- a/app/src/main/res/layout/activity_main.xml
+++ b/app/src/main/res/layout/activity_main.xml
@@ -28,6 +28,7 @@
         android:layout_height="wrap_content"
         android:layout_gravity="bottom|end"
         android:layout_margin="@dimen/fab_margin"
-        app:srcCompat="@android:drawable/ic_dialog_email" />
+        android:tint="@color/colorIcons"
+        app:srcCompat="@drawable/ic_add_black_24dp" />
 
 </android.support.design.widget.CoordinatorLayout>

--- a/app/src/main/res/values/colors.xml
+++ b/app/src/main/res/values/colors.xml
@@ -1,6 +1,11 @@
 <?xml version="1.0" encoding="utf-8"?>
-<resources>
-    <color name="colorPrimary">#008577</color>
-    <color name="colorPrimaryDark">#00574B</color>
-    <color name="colorAccent">#D81B60</color>
+<resources xmlns:tools="http://schemas.android.com/tools">
+    <color name="colorPrimary">#3F51B5</color>
+    <color name="colorPrimaryDark">#303F9F</color>
+    <color name="colorPrimaryLight" tools:keep="@color/colorPrimaryLight">#C5CAE9</color>
+    <color name="colorAccent">#8BC34A</color>
+    <color name="colorPrimaryText" tools:keep="@color/colorPrimaryText">#212121</color>
+    <color name="colorSecondaryText" tools:keep="@color/colorSecondaryText">#757575</color>
+    <color name="colorIcons">#ffffff</color>
+    <color name="colorDivider" tools:keep="@color/colorDivider">#BDBDBD</color>
 </resources>

--- a/notes.org
+++ b/notes.org
@@ -1,0 +1,5 @@
+* Intractable problems to solve
+** JUnit 5
++ Following the instruction at https://github.com/mannodermaus/android-junit5 leads to an unresolved class having to do
+  with Jacoco.  If you have Android Studio 3.3 Canary 11 (or later) with Jacoco, Kotlin and Junit5, I'd love to see your
+  build scripts.


### PR DESCRIPTION
Rationale:
=========

This commit makes the FAB more like the original Argus and disables the Snackbar baseline behavior.

In addition, the version information has been adjusted for the next Argus release to the Play store.

And finally, some testing Lint warnings have been applied.

File changes:
============
modified:   app/build.gradle

- Summary: upgrade the version information for the next release and establish Java 1.8 source code levels.

modified:   app/src/androidTest/java/com/pajato/argus/MainActivityTest.kt

- Summary: fix some Lint warnings and remove a stale FAB test.

modified:   app/src/main/java/com/pajato/argus/MainActivity.kt

- Summary: remove the anonymous click handler for the FAB.

new file:   app/src/main/res/drawable/ic_add_black_24dp.xml
modified:   app/src/main/res/layout/activity_main.xml
modified:   app/src/main/res/values/colors.xml

- Summary: update the look for the FAB.

new file:   notes.org

- Summary: provide a notes placeholder for issues to discuss at meet-ups.